### PR TITLE
Use Java 17 to make it work with React Native 0.73.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ android {
     disable "GradleCompatible"
   }
 
-  def java_version = JavaVersion.VERSION_11
+  def java_version = JavaVersion.VERSION_17
 
   compileOptions {
     sourceCompatibility java_version
@@ -100,4 +100,3 @@ dependencies {
   // https://mvnrepository.com/artifact/com.sunmi/printerlibrary
   implementation "com.sunmi:printerlibrary:1.0.22"
 }
-


### PR DESCRIPTION
Hi,

I'm using this lib with React Native `0.73.5`, and compilation fails with the following error:

```
Execution failed for task ':mitsuharu_react-native-sunmi-printer-library:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 17) and 'compileDebugKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version. Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
``

Not sure this is the best fix, maybe `sourceCompatibility` should be removed entirely?