### PR TITLE
chore: Aikido Safe Chainを1.5.16へ更新

### DIFF
--- a/.github/workflows/aikidosec-safe-chain.yml
+++ b/.github/workflows/aikidosec-safe-chain.yml
@@ -2,6 +2,10 @@
 # https://github.com/AikidoSec/safe-chain
 name: Check npm packages by AikidoSec Safe Chain
 
+env:
+  AIKIDO_SAFE_CHAIN_VERSION: '1.5.16'
+  AIKIDO_SAFE_CHAIN_INSTALLER_SHA256: '7a7b6e54c2e0adbcb53bc1bf7d258cc974f8f31e77ed048b88e4d2e4ac758839'
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -24,13 +28,16 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: '.node-version'
-          cache: 'npm'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
 
-      # AikidoSec Safe Chain　をセットアップ
+      # AikidoSec Safe Chainをセットアップ
       - name: Setup safe-chain
         run: |
-          npm i -g @aikidosec/safe-chain@1.1.5
-          safe-chain setup-ci
+          curl -fsSL "https://github.com/AikidoSec/safe-chain/releases/download/${AIKIDO_SAFE_CHAIN_VERSION}/install-safe-chain.sh" -o /tmp/install-safe-chain.sh
+          echo "${AIKIDO_SAFE_CHAIN_INSTALLER_SHA256}  /tmp/install-safe-chain.sh" | sha256sum -c -
+          sh /tmp/install-safe-chain.sh --ci
+          rm /tmp/install-safe-chain.sh
 
       # lock ファイルに基づいて依存関係をインストールする
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "lint-force": "biome check --write",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
     "prepare": "bob build",
-    "release": "release-it",
-    "install:safe-chain": "npm install -g @aikidosec/safe-chain@1.1.5 && safe-chain setup && ./scripts/relogin.sh",
-    "uninstall:safe-chain": "safe-chain teardown && npm uninstall -g @aikidosec/safe-chain && ./scripts/relogin.sh"
+    "release": "release-it"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
## 概要

Aikido Safe Chainを最新安定版の `1.5.16` へ更新し、現在の公式CI/CD手順に合わせて導入方法を変更しました。

## 変更内容

- npmのグローバルパッケージではなく、GitHub Releasesのバージョン固定インストーラーを利用
- インストーラーを実行する前にSHA-256を検証
- Safe Chainを `--ci` オプションでセットアップ
- バージョンとインストーラーのSHA-256をワークフロー上部の環境変数へ集約
- `package.json` から `install:safe-chain` / `uninstall:safe-chain` を削除
- Node.jsの依存関係キャッシュをnpmからYarn（`yarn.lock`）へ変更

## 検証

- 公式リリースのインストーラー取得およびSHA-256一致確認: 成功
- インストーラーのシェル構文確認（`sh -n`）: 成功
- GitHub ActionsワークフローのYAML構文確認: 成功
- `package.json` のJSON構文確認: 成功
- `yarn install --immutable`: 成功（既存のpeer dependency警告のみ）
- `yarn lint`: 成功
- GitHub Actions `check-npm-packages-by-aikidosec-safe-chain`: 成功
- GitHub Actions `lint_and_test`: 成功
- GitHub Actions `build_android_example`: 成功

アプリおよびネイティブ実装の変更はないため、SUNMI実機での印刷確認は対象外です。
