### PR TITLE
fix: bitmap印刷時のアスペクト比計算を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           corepack enable
           yarn install --immutable
 
+      - name: Test Android library
+        run: yarn test:android
+
       - name: Build Android example
         run: yarn example build:android
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 yarn typecheck
 yarn lint
 yarn test
+yarn test:android
 yarn example build:android
 yarn example:expo build:android
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -103,4 +103,6 @@ dependencies {
 
   // https://mvnrepository.com/artifact/com.sunmi/printerlibrary
   implementation "com.sunmi:printerlibrary:1.0.24"
+
+  testImplementation "junit:junit:4.13.2"
 }

--- a/android/src/main/java/com/sunmiprinterlibrary/BitmapDimensions.kt
+++ b/android/src/main/java/com/sunmiprinterlibrary/BitmapDimensions.kt
@@ -1,0 +1,7 @@
+package com.sunmiprinterlibrary
+
+internal fun calculateScaledBitmapHeight(
+  targetWidth: Int,
+  sourceWidth: Int,
+  sourceHeight: Int,
+): Int = (targetWidth.toLong() * sourceHeight / sourceWidth).toInt()

--- a/android/src/main/java/com/sunmiprinterlibrary/SunmiPrinterLibraryModule.kt
+++ b/android/src/main/java/com/sunmiprinterlibrary/SunmiPrinterLibraryModule.kt
@@ -560,7 +560,8 @@ class SunmiPrinterLibraryModule(reactContext: ReactApplicationContext) :
       val decodedBitmap = BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.size)
       val w = decodedBitmap.width
       val h = decodedBitmap.height
-      val image = Bitmap.createScaledBitmap(decodedBitmap, pixelWidth, pixelWidth / w * h, false)
+      val scaledHeight = calculateScaledBitmapHeight(pixelWidth, w, h)
+      val image = Bitmap.createScaledBitmap(decodedBitmap, pixelWidth, scaledHeight, false)
       printerService?.printBitmap(image, callback)
     } catch (e: Exception) {
       promise.reject("0", "native#printBitmapBase64 is failed. " + e.message)
@@ -577,7 +578,8 @@ class SunmiPrinterLibraryModule(reactContext: ReactApplicationContext) :
       val decodedBitmap = BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.size)
       val w = decodedBitmap.width
       val h = decodedBitmap.height
-      val image = Bitmap.createScaledBitmap(decodedBitmap, pixelWidth, pixelWidth / w * h, false)
+      val scaledHeight = calculateScaledBitmapHeight(pixelWidth, w, h)
+      val image = Bitmap.createScaledBitmap(decodedBitmap, pixelWidth, scaledHeight, false)
       printerService?.printBitmapCustom(image, type, callback)
     } catch (e: Exception) {
       promise.reject("0", "native#printBitmapBase64Custom is failed. " + e.message)

--- a/android/src/test/java/com/sunmiprinterlibrary/BitmapDimensionsTest.kt
+++ b/android/src/test/java/com/sunmiprinterlibrary/BitmapDimensionsTest.kt
@@ -1,0 +1,21 @@
+package com.sunmiprinterlibrary
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BitmapDimensionsTest {
+  @Test
+  fun `calculates a non-zero height when source is wider than target`() {
+    assertEquals(256, calculateScaledBitmapHeight(384, 1080, 720))
+  }
+
+  @Test
+  fun `preserves the aspect ratio when enlarging an image`() {
+    assertEquals(300, calculateScaledBitmapHeight(576, 384, 200))
+  }
+
+  @Test
+  fun `uses long arithmetic before multiplication`() {
+    assertEquals(4_000_000, calculateScaledBitmapHeight(2, 1, 2_000_000))
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "example": "yarn workspace react-native-sunmi-printer-library-example",
     "example:expo": "yarn workspace react-native-sunmi-printer-library-expo-example",
     "test": "jest",
+    "test:android": "cd example/android && ./gradlew :mitsuharu_react-native-sunmi-printer-library:testDebugUnitTest --no-daemon --console=plain",
     "typecheck": "tsc --noEmit",
     "lint": "biome check",
     "lint-force": "biome check --write",


### PR DESCRIPTION
## 概要

PR #150 の1番目のコミット（1d56efc6ae402b1cef3f911ba0451a8ffb63f8c4）を参考に、Base64画像を印刷幅へ拡大・縮小する際の高さ計算を修正します。

従来は pixelWidth / sourceWidth * sourceHeight の順に整数除算していたため、元画像が印刷幅より広い場合は高さが0になり、拡大時にもアスペクト比が崩れる場合がありました。乗算を先に行い、途中計算をLongにすることで比率を保ちつつIntオーバーフローを避けます。

## 変更内容

- printBitmapBase64 と printBitmapBase64Custom で共通の高さ計算を使用
- 縮小、拡大、途中計算のオーバーフローを対象にKotlin単体テストを追加
- Android単体テスト用にJUnit 4を追加
- yarn test:android を追加し、React Native exampleのAndroid CIジョブで実行
- AGENTS.mdの必須検証へAndroid単体テストを追加
- PR #150 の2番目のコミットに含まれるlib生成物、prepare削除、tsconfig変更は対象外

## 検証

- [x] yarn typecheck
- [x] yarn lint
- [x] yarn test --runInBand --no-watchman
- [x] yarn test:android
- [x] yarn prepare
- [x] yarn example build:android
- [x] yarn example:expo build:android

## 実機確認

- [x] SUNMI V2 PROへExpo版debug APKを上書きインストール
- [x] com.sunmiprinterlibraryexpoexample/.MainActivity の前面起動を確認
- [x] サンプルアプリから画像を問題なく印刷できることを確認

縮尺計算はKotlin単体テストとSUNMI V2 PROでの実機印刷の両方で検証済みです。