### PR TITLE
chore: prepare release 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitsuharu/react-native-sunmi-printer-library",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "React Native module that support SUNMI mobile printer devices.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

- update the package version from `2.4.0` to `3.0.0` for the next major release
- keep the release tag aligned with the version consumed by the manual release workflow

## Validation

- `yarn install --immutable`
- `yarn typecheck`
- `yarn lint`
- `yarn test --runInBand --no-watchman`
- `npm pack --dry-run` using a temporary local npm cache; confirmed `@mitsuharu/react-native-sunmi-printer-library@3.0.0`

## Release

After this pull request is merged and CI succeeds, manually run **Release to npm** with version `3.0.0`. Merging this pull request does not publish the package.

## Device testing

Not run. This pull request only changes package metadata.