### PR TITLE
Remove commit message prefix from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     directory: '/'
     target-branch: 'main'
     open-pull-requests-limit: 10
-    commit-message:
-      prefix: '[skip ci] '
     schedule:
       interval: 'weekly'
     groups:
@@ -25,7 +23,5 @@ updates:
     target-branch: 'main'
     schedule:
       interval: 'monthly'
-    commit-message:
-      prefix: '[skip ci] '
     cooldown:
       default-days: 7


### PR DESCRIPTION
Removed commit message prefix configuration for npm and monthly updates.