### PR TITLE
ci: JSバンドル検証の追加とBabelメジャー更新のignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,16 @@ updates:
         patterns:
           - 'textlint'
           - 'textlint-*'
+    # React Nativeが対応するまでBabelのメジャー更新を保留します。
+    # @react-native/babel-preset は @babel/core ^7 に依存しており、
+    # exampleのBabelはReact Nativeのテンプレート由来の直接依存です。
+    ignore:
+      - dependency-name: '@babel/core'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@babel/preset-env'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@babel/runtime'
+        update-types: ['version-update:semver-major']
     cooldown:
       default-days: 7
   - package-ecosystem: 'github-actions'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,34 @@ jobs:
       - name: Test
         run: yarn test
 
+  bundle_javascript:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version-file: '.node-version'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+
+      - name: Install dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
+
+      # AndroidのassembleDebugはJSをバンドルしないため、
+      # BabelとMetroの変更はこのジョブでのみ検証されます。
+      - name: Bundle JavaScript of example
+        run: yarn example bundle:android
+
+      - name: Bundle JavaScript of Expo example
+        run: yarn example:expo bundle:android
+
   build_android_example:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,11 +30,15 @@ yarn typecheck
 yarn lint
 yarn test
 yarn test:android
+yarn example bundle:android
+yarn example:expo bundle:android
 yarn example build:android
 yarn example:expo build:android
 ```
 
 2つのAndroid exampleのビルドでは、`armeabi-v7a` と `arm64-v8a` 向けに `assembleDebug` を実行します。この検証で確認できるのはコンパイルとリンクまでです。プリンターの実動作は、対応するSUNMI端末で別途確認します。
+
+`assembleDebug` はJSをバンドルしないため、AndroidビルドではMetroとBabelを一切実行しません。Babel、Metro、JS依存関係を変更したときは、2つの `bundle:android` でJSバンドルまで確認します。
 
 ## Expo exampleの開発
 

--- a/example-expo/package.json
+++ b/example-expo/package.json
@@ -9,6 +9,7 @@
     "doctor": "expo-doctor",
     "typecheck": "tsc --noEmit",
     "prebuild:android": "expo prebuild --platform android --clean --no-install",
+    "bundle:android": "expo export --platform android --output-dir build/export --clear",
     "build:android:native": "cd android && NODE_ENV=development ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=armeabi-v7a,arm64-v8a",
     "build:android": "yarn prebuild:android && yarn build:android:native"
   },

--- a/example/package.json
+++ b/example/package.json
@@ -6,6 +6,7 @@
     "android": "react-native run-android",
     "ios": "echo 'iOS is not supported in this project.' && exit 1",
     "start": "react-native start",
+    "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output build/index.android.bundle --assets-dest build",
     "build:android": "cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=armeabi-v7a,arm64-v8a",
     "build:ios": "cd ios && xcodebuild -workspace SunmiPrinterLibraryExample.xcworkspace -scheme SunmiPrinterLibraryExample -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO"
   },


### PR DESCRIPTION
## 概要

Dependabotが出しているBabel 8系のPR（#177 #182 #183）を確認する過程で、CIがMetroとBabelを一度も実行していないことが分かったため、検証を追加します。

- CIのAndroidビルドは2つとも `assembleDebug` で、React Native / ExpoのdebugビルドはJSをバンドルしません。つまりMetroもBabelも起動していません。
- Babel経路を通るのはルートの `yarn test` のみで、テストは2ケースだけです。
- 結果として、Babelや依存関係の更新はCIが緑でも「壊れていない」ではなく「実行されていない」状態でした。

## 変更内容

### 1. JSバンドル検証の追加（`1fe8d55`）

- `example` に `bundle:android`（`react-native bundle --dev false`）を追加
- `example-expo` に `bundle:android`（`expo export --platform android`）を追加
- CIに `bundle_javascript` ジョブを追加。Gradle・Android SDKが不要なため、実行時間は両方あわせて十数秒です
- AGENTS.md の必須の検証へ2コマンドを追記し、`assembleDebug` がJSをバンドルしない点を明記

### 2. Babelのメジャー更新をignore（`c225157`）

`@react-native/babel-preset@0.87.1` は `@babel/core: ^7.25.2` に依存しており、React NativeがBabel 8へ対応するまでメジャー更新は取り込めません。`@babel/core` `@babel/preset-env` `@babel/runtime` の `version-update:semver-major` をignoreします。7系のminor/patchは従来どおり更新されます。

なお `@babel/preset-env` は `example/babel.config.js` からも他のどの設定からも参照されておらず、React Nativeテンプレート由来の未使用依存です。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | pass |
| `yarn lint` | pass（23 files） |
| `yarn test` | pass（1 suite / 2 tests） |
| `yarn example bundle:android` | pass（1.0MB のbundleを出力） |
| `yarn example:expo bundle:android` | pass（1.6MB のhbcを出力） |

追加したジョブが実際に失敗を検出できることの確認として、`example/babel.config.js` のpresetを存在しない名前へ差し替えたところ、`yarn example bundle:android` は exit code 1 で失敗しました（確認後に復元済み）。

Babel 8のPRブランチ（#182 / #177）でもバンドルを実行し、いずれも成功することを確認しています。Babel 8は「バンドルを壊す」のではなく、Metroとjestがルートにホイストされた `@babel/core@7.29.7` を解決するため、exampleに入る8系が使われないまま重複するという状態でした。

SUNMI実機での印刷確認は、CIとDependabot設定のみの変更のため実施していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)