### PR TITLE
chore: Dependabotの更新をグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,36 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: 'weekly'
+    # 互換性を揃えて更新する必要がある依存関係をまとめます。
+    # パターンは前方一致ではないため、`react-native` のような完全一致は
+    # `react-native-safe-area-context` を巻き込みません。
     groups:
-      update-textlint:
+      react-native:
         patterns:
-          - 'textlint'
-          - 'textlint-*'
+          - 'react-native'
+          - '@react-native/*'
+          - '@react-native-community/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-test-renderer'
+          - '@types/react'
+          - '@types/react-test-renderer'
+      expo:
+        patterns:
+          - 'expo'
+          - 'expo-*'
+          - '@expo/*'
+      jest:
+        patterns:
+          - 'jest'
+          - 'jest-*'
+          - '@jest/*'
+          - 'babel-jest'
+          - '@types/jest'
+      babel:
+        patterns:
+          - '@babel/*'
     # React Nativeが対応するまでBabelのメジャー更新を保留します。
     # @react-native/babel-preset は @babel/core ^7 に依存しており、
     # exampleのBabelはReact Nativeのテンプレート由来の直接依存です。


### PR DESCRIPTION
## 概要

互換性を揃えて更新する必要がある依存関係が別々のPRになると、片方だけマージした時点で不整合になります。実際に #178（react-test-renderer 19.2.8）は単体だと peer が `react: ^19.2.8` を要求するため、#180 と同時でなければ壊れる状態でした。これをグループ化で防ぎます。

## グループ

| グループ | 対象 |
| --- | --- |
| `react-native` | `react-native`, `@react-native/*`, `@react-native-community/*` |
| `react` | `react`, `react-test-renderer`, `@types/react`, `@types/react-test-renderer` |
| `expo` | `expo`, `expo-*`, `@expo/*` |
| `jest` | `jest`, `jest-*`, `@jest/*`, `babel-jest`, `@types/jest` |
| `babel` | `@babel/*` |

`react-native` と `react` はAGENTS.mdの「React Nativeの更新」に沿って互換セットで一括更新するため、`expo` はExpo SDKのバージョンセットが連動するため、`jest` はランナーとtransformerとtypesが揃っている必要があるためまとめています。

パターンは前方一致ではないので、`react-native` の完全一致は `react-native-safe-area-context` や `react-native-builder-bob` を巻き込みません。実際の依存関係名で照合し、いずれのパッケージも複数グループに一致しないことを確認済みです。

グループ外（個別PRのまま）: `@biomejs/biome`, `agent-device`, `babel-plugin-module-resolver`, `buffer`, `del-cli`, `prettier`, `react-native-builder-bob`, `react-native-safe-area-context`, `turbo`, `typescript`

GitHub Actionsは対象が `actions/checkout`, `actions/setup-node`, `actions/setup-java`, `gradle/actions/setup-gradle` の4つだけで、更新も月次です。SHAピン留めの差分は個別に確認したいため、グループ化しません。

## textlintグループの削除

既存の `update-textlint` グループが対象にしている `textlint` / `textlint-*` は、ルート・`example`・`example-expo` のいずれにも存在しません。動作していない設定のため削除します。

## 検証

`.github/dependabot.yml` のみの変更のため、ビルドと実機確認は実施していません。YAMLがパースできること、および上記のパターン照合を確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)